### PR TITLE
Hide Duplicate Image from Rendered Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Welcome to Tickets+
-
-<img align="left" src="https://raw.githubusercontent.com/Tech-TTGames/Tickets-Plus/main/branding/rounded.png" height="200" width="200" alt="The Tickets Plus logo"/>
+<div class="github-only" style="display:none;">
+  <img align="left" src="https://raw.githubusercontent.com/Tech-TTGames/Tickets-Plus/main/branding/rounded.png" height="200" width="200" alt="The Tickets Plus logo"/>
+</div>
 
 [![CodeQL](https://github.com/Tech-TTGames/Tickets-Plus/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/Tech-TTGames/Tickets-Plus/actions/workflows/codeql.yml) [![Pylint](https://github.com/Tech-TTGames/Tickets-Plus/actions/workflows/pylint.yml/badge.svg?branch=main)](https://github.com/Tech-TTGames/Tickets-Plus/actions/workflows/pylint.yml) [![DeepSource](https://deepsource.io/gh/Tech-TTGames/Tickets-Plus.svg/?label=active+issues&show_trend=true&token=ourUeg696DFMDcZDoZi0ZqGn)](https://deepsource.io/gh/Tech-TTGames/Tickets-Plus/?ref=repository-badge) [![](https://shields.tosdr.org/en_9853.svg)](https://tosdr.org/en/service/9853)
 
@@ -110,4 +111,4 @@ Here are the steps to host your copy of [this bot.](https://github.com/Tech-TTGa
 [^2]: This setup assumes you have the main bot added to the server and configured. Support will not be provided to those who do not assume a likewise configuration.
 [^3]: Staff role defined in per-server settings.
 [^4]: Community roles defined in per-server settings.
-[^5]: Tickets bot defined in per-server settings.
+[^5]: Tickets bot defined in per-server settings. 


### PR DESCRIPTION
## Description

Having two of the same image on the website so close is a bit ugly. Plus, that wrap around is HORRID! 
## Motivation and Context

My eyes.

## Changes Made

I just add some simple style _**Features**_ that won't render in the README but will on Pages. The amazing, innovative... `style="display: none;"`

## Additionally Comments

PS I think your PR template could use some YAML (stinky)

## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have reviewed my own code and ensured it passes all linting tests.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have run all tests and ensured they pass.
